### PR TITLE
chore: upgrade rider build number to 243.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ build/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml
+.idea/projectSettingsUpdater.xml
+.idea/indexLayout.xml
 .idea/libraries/
 *.iws
 *.iml
@@ -15,6 +17,7 @@ build/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+.intellijPlatform
 
 ### Eclipse ###
 .apt_generated

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("232")
-        untilBuild.set("242.*")
+        untilBuild.set("243.*")
     }
 
     signPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.kevinmueller"
-version = "1.0.7"
+version = "1.0.8"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Fixes #2 

Tested and Working on 2023.2 and 2024.3

Improvements we can still do:
- Upgrade         rider("2023.2")  to rider("2024.3")
- Remove the untilBuild, so we don't have to update this plugin every quarters (this plugin is quite simple and will probably not be affected by future version changes)